### PR TITLE
Make native window code work on both native X11 and XWayland

### DIFF
--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/WindowHandler.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/WindowHandler.cs
@@ -47,10 +47,6 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         static Texture2D resizeBorderTexture;
         bool resizeCursorActive;
         CursorStyle activeResizeCursor;
-        bool isNativeResizing;
-        Vector2Int resizeStartPointer;
-        RectInt resizeStartRect;
-        WindowResizeEdge resizeEdge;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         public static void InitializeWindow()
@@ -107,15 +103,17 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             }
 
             UpdateResizeEdges();
+        }
 
-            if (isDragging && !framed && NativeWindow.IsApiAvailable)
-            {
-                Vector2Int currentPointer = targetWindow.GetPointerPosition();
-                Vector2Int delta = currentPointer - dragStartPointer;
-                Vector2Int newPos = dragStartWindowPos + delta;
-                if (newPos != targetWindow.Position)
-                    targetWindow.Position = newPos;
-            }
+        // Convert Unity's window-local cursor position (bottom-left origin) to the
+        // root-relative coordinates EWMH _NET_WM_MOVERESIZE expects (top-left origin).
+        Vector2Int GetRootPointer()
+        {
+            RectInt rect = targetWindow.Rect;
+            Vector2 mouse = Input.mousePosition;
+            return new Vector2Int(
+                rect.x + Mathf.RoundToInt(mouse.x),
+                rect.y + Mathf.RoundToInt(Screen.height - mouse.y));
         }
 
         public void OnFrameChanged()
@@ -158,7 +156,9 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
             if (NativeWindow.IsApiAvailable) targetWindow.State = maximized ? WindowState.Maximized : WindowState.Floating;
 
-            if (NativeWindow.IsApiAvailable)
+            // Nudge the window back on-screen after restoring. No-op (and unnecessary)
+            // under XWayland, where the compositor owns placement.
+            if (NativeWindow.IsApiAvailable && targetWindow.SupportsClientPositioning)
             {
                 var rect = targetWindow.Rect;
                 if (!maximized && rect.yMin < 0) targetWindow.Position += Vector2Int.up * rect.yMin;
@@ -167,11 +167,15 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             OnSizeChange();
         }
 
-        public void FinalizeDrag() 
+        public void FinalizeDrag()
         {
-            if (!maximized) 
+            // The custom "drag to top edge = maximize" gesture and the on-screen nudge
+            // both rely on client-controlled positioning, so they only run on native X11.
+            // Under XWayland the compositor handles its own drag, top-edge snap, and
+            // placement during the compositor-mediated move.
+            if (!maximized)
             {
-                if (!NativeWindow.IsApiAvailable) return;
+                if (!NativeWindow.IsApiAvailable || !targetWindow.SupportsClientPositioning) return;
                 var rect = targetWindow.Rect;
                 if (rect.yMin - Input.mousePosition.y + Screen.height < 1 && !maximized) ResizeWindow();
                 else if (rect.yMin < 0) targetWindow.Position += Vector2Int.up * rect.yMin;
@@ -204,21 +208,7 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
         void UpdateResizeEdges()
         {
-            if (isNativeResizing)
-            {
-                if ((targetWindow.GetPointerButtonMask() & 0x100) != 0)
-                {
-                    UpdateManualResize(false);
-                    return;
-                }
-                else
-                {
-                    UpdateManualResize(true); // Force final sync on release
-                    isNativeResizing = false;
-                }
-            }
-
-            if (!NativeWindow.IsApiAvailable || framed || maximized || isFullScreen || isDragging)
+            if (!NativeWindow.IsApiAvailable || framed || maximized || isFullScreen)
             {
                 ClearResizeCursor();
                 return;
@@ -236,98 +226,12 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
 
             if (Input.GetMouseButtonDown(0))
             {
-                targetWindow.StartResize(targetWindow.GetPointerPosition(), edge);
-                resizeStartPointer = targetWindow.GetPointerPosition();
-                resizeStartRect = targetWindow.Rect;
-                resizeEdge = edge;
-                isNativeResizing = true;
+                // Delegate the resize to the WM / compositor via EWMH _NET_WM_MOVERESIZE.
+                // Works on native X11 and XWayland on all compositors; min-size is enforced
+                // by the WM from the window's size hints (set via NativeWindow.MinSize).
+                targetWindow.StartResize(GetRootPointer(), edge);
                 EventSystem.current.SetSelectedGameObject(null);
             }
-        }
-
-        float lastResizeTime;
-        const float ResizeThrottleInterval = 0.05f; // 50ms
-
-        void UpdateManualResize(bool force)
-        {
-            if (!force && Time.realtimeSinceStartup - lastResizeTime < ResizeThrottleInterval)
-                return;
-
-            Vector2Int delta = targetWindow.GetPointerPosition() - resizeStartPointer;
-            RectInt rect = resizeStartRect;
-            Vector2Int minSize = targetWindow.MinSize;
-
-            switch (resizeEdge)
-            {
-                case WindowResizeEdge.TopLeft:
-                    rect.xMin += delta.x;
-                    rect.yMin += delta.y;
-                    break;
-                case WindowResizeEdge.Top:
-                    rect.yMin += delta.y;
-                    break;
-                case WindowResizeEdge.TopRight:
-                    rect.xMax += delta.x;
-                    rect.yMin += delta.y;
-                    break;
-                case WindowResizeEdge.Right:
-                    rect.xMax += delta.x;
-                    break;
-                case WindowResizeEdge.BottomRight:
-                    rect.xMax += delta.x;
-                    rect.yMax += delta.y;
-                    break;
-                case WindowResizeEdge.Bottom:
-                    rect.yMax += delta.y;
-                    break;
-                case WindowResizeEdge.BottomLeft:
-                    rect.xMin += delta.x;
-                    rect.yMax += delta.y;
-                    break;
-                case WindowResizeEdge.Left:
-                    rect.xMin += delta.x;
-                    break;
-            }
-
-            rect = ApplyResizeMinSize(rect, minSize, resizeEdge);
-            RectInt currentRect = targetWindow.Rect;
-
-            bool sizeChanged = rect.width != Screen.width || rect.height != Screen.height;
-            bool posChanged = rect.x != currentRect.x || rect.y != currentRect.y;
-
-            if (sizeChanged || posChanged || force)
-            {
-                lastResizeTime = Time.realtimeSinceStartup;
-                targetWindow.Rect = rect;
-                if (force)
-                {
-                    Screen.SetResolution(rect.width, rect.height, FullScreenMode.Windowed);
-                }
-            }
-        }
-
-        RectInt ApplyResizeMinSize(RectInt rect, Vector2Int minSize, WindowResizeEdge edge)
-        {
-            minSize.x = Mathf.Max(minSize.x, 1);
-            minSize.y = Mathf.Max(minSize.y, 1);
-
-            if (rect.width < minSize.x)
-            {
-                if (edge == WindowResizeEdge.Left || edge == WindowResizeEdge.TopLeft || edge == WindowResizeEdge.BottomLeft)
-                    rect.xMin = rect.xMax - minSize.x;
-                else
-                    rect.xMax = rect.xMin + minSize.x;
-            }
-
-            if (rect.height < minSize.y)
-            {
-                if (edge == WindowResizeEdge.Top || edge == WindowResizeEdge.TopLeft || edge == WindowResizeEdge.TopRight)
-                    rect.yMin = rect.yMax - minSize.y;
-                else
-                    rect.yMax = rect.yMin + minSize.y;
-            }
-
-            return rect;
         }
 
         bool TryGetResizeEdge(Vector2 mousePosition, out WindowResizeEdge edge)
@@ -404,27 +308,19 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             if (NativeWindow.IsApiAvailable) targetWindow.SetHitTestZone((int)WindowZone.Client);
         }
 
-        Vector2Int dragStartWindowPos;
-        Vector2Int dragStartPointer;
-        bool isDragging;
-
         public void OnBeginDrag(PointerEventData data)
         {
-            if (framed || maximized || isNativeResizing || TryGetResizeEdge(Input.mousePosition, out _) || !NativeWindow.IsApiAvailable) return;
+            if (framed || maximized || TryGetResizeEdge(Input.mousePosition, out _) || !NativeWindow.IsApiAvailable) return;
 
-            if (targetWindow.StartDrag(targetWindow.GetPointerPosition()))
-                return;
-
-            dragStartPointer = targetWindow.GetPointerPosition();
-            dragStartWindowPos = targetWindow.Position;
-            isDragging = true;
+            // Delegate the move to the WM / compositor via EWMH _NET_WM_MOVERESIZE.
+            // Works on native X11 and XWayland on all compositors.
+            targetWindow.StartDrag(GetRootPointer());
         }
 
         public void OnDrag(PointerEventData data) { }
 
         public void OnEndDrag(PointerEventData data)
         {
-            isDragging = false;
             if (!NativeWindow.IsApiAvailable) return;
             FinalizeDrag();
         }

--- a/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/WindowHandler.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Behaviors/Chartmaker/WindowHandler.cs
@@ -48,6 +48,12 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         bool resizeCursorActive;
         CursorStyle activeResizeCursor;
 
+        // Last known floating (non-maximized) geometry, tracked each frame so it can be
+        // persisted on quit and restored next launch — Unity/engine init otherwise wipes it.
+        Vector2Int lastFloatingPos;
+        Vector2Int lastFloatingSize;
+        bool hasFloatingRect;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         public static void InitializeWindow()
         {
@@ -67,6 +73,50 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
         {
             main = this;
             targetWindow = NativeWindow.MainWindow;
+        }
+
+        public void Start()
+        {
+            RestoreWindowGeometry();
+        }
+
+        // Re-applies the window size/position saved last session. Runs in Start (not the
+        // BeforeSplashScreen init) so engine/Unity window setup has settled and won't wipe it.
+        void RestoreWindowGeometry()
+        {
+            if (!NativeWindow.IsApiAvailable) return;
+
+            var prefs = Chartmaker.Preferences;
+            if (prefs.WindowWidth <= 0 || prefs.WindowHeight <= 0) return; // nothing saved yet
+
+            Screen.SetResolution(prefs.WindowWidth, prefs.WindowHeight, FullScreenMode.Windowed);
+
+            // Position is compositor-owned under XWayland; only meaningful on native X11.
+            if (targetWindow.SupportsClientPositioning)
+                targetWindow.Position = new Vector2Int(prefs.WindowX, prefs.WindowY);
+
+            lastFloatingPos = new Vector2Int(prefs.WindowX, prefs.WindowY);
+            lastFloatingSize = new Vector2Int(prefs.WindowWidth, prefs.WindowHeight);
+            hasFloatingRect = true;
+
+            if (prefs.WindowMaximized)
+                targetWindow.State = WindowState.Maximized;
+        }
+
+        public void OnApplicationQuit()
+        {
+            if (!NativeWindow.IsApiAvailable || Chartmaker.PreferencesStorage == null) return;
+
+            var storage = Chartmaker.PreferencesStorage;
+            if (hasFloatingRect)
+            {
+                storage.Set("LA:WindowX", lastFloatingPos.x);
+                storage.Set("LA:WindowY", lastFloatingPos.y);
+                storage.Set("LA:WindowWidth", lastFloatingSize.x);
+                storage.Set("LA:WindowHeight", lastFloatingSize.y);
+            }
+            storage.Set("LA:WindowMaximized", maximized);
+            storage.Save();
         }
 
         public void Quit()
@@ -103,6 +153,16 @@ namespace JANOARG.Chartmaker.Behaviors.Chartmaker
             }
 
             UpdateResizeEdges();
+
+            // Remember the latest floating geometry so a maximized-at-close still saves a
+            // sane restore size, and so position survives across launches (native X11).
+            if (NativeWindow.IsApiAvailable && !maximized && !isFullScreen
+                && Screen.width > 0 && Screen.height > 0)
+            {
+                lastFloatingPos = targetWindow.Position;
+                lastFloatingSize = new Vector2Int(Screen.width, Screen.height);
+                hasFloatingRect = true;
+            }
         }
 
         // Convert Unity's window-local cursor position (bottom-left origin) to the

--- a/Assets/JANOARG.Chartmaker/Scripts/Constants/ChartmakerPrefs.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Constants/ChartmakerPrefs.cs
@@ -31,6 +31,12 @@ namespace JANOARG.Chartmaker.Constants
         public bool  ForceNavigationBar;
         public float InterfaceScaling = 1;
 
+        public int  WindowX;
+        public int  WindowY;
+        public int  WindowWidth;
+        public int  WindowHeight;
+        public bool WindowMaximized;
+
         public void Load(Storage storage)
         {
             MaximizeOnPlay = storage.Get("PL:MaximizeOnPlay", MaximizeOnPlay);
@@ -46,7 +52,13 @@ namespace JANOARG.Chartmaker.Constants
             ForceNavigationBar = storage.Get("LA:ForceNavigationBar", true);
             
             InterfaceScaling = storage.Get("LA:UIScalingFactor", InterfaceScaling);
-        
+
+            WindowX = storage.Get("LA:WindowX", WindowX);
+            WindowY = storage.Get("LA:WindowY", WindowY);
+            WindowWidth = storage.Get("LA:WindowWidth", WindowWidth);
+            WindowHeight = storage.Get("LA:WindowHeight", WindowHeight);
+            WindowMaximized = storage.Get("LA:WindowMaximized", WindowMaximized);
+
             QualitySettings.vSyncCount = storage.Get("GS:VSync", 1);
             QualitySettings.antiAliasing = storage.Get("GS:AntiAliasing", 0);
 

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/INativeWindowProvider.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/INativeWindowProvider.cs
@@ -4,6 +4,13 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow
 {
     internal interface INativeWindowProvider : INativeAPIProvider<NativeWindowController>
     {
+        /// <summary>
+        /// Whether the app can position/size its own top-level window directly.
+        /// True on native X11 (and Windows); false under XWayland, where the
+        /// compositor owns window placement and client positioning is ignored.
+        /// </summary>
+        public bool SupportsClientPositioning { get; }
+
         public nint GetMainWindowHandle();
 
         public bool HookWindow(nint windowHandle);

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/LinuxX11/LinuxX11NativeWindowProvider.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/LinuxX11/LinuxX11NativeWindowProvider.cs
@@ -390,6 +390,20 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
         {
             if (!CanUseWindow(windowHandle)) return false;
 
+            // Capture the content (client) rect before toggling decorations so the
+            // content size/position can be kept constant across the change. Skipped when
+            // the style isn't actually changing or while maximized (that state owns the
+            // geometry).
+            WindowStyle previousStyle = GetWindowStyle(windowHandle);
+            bool preserveGeometry = previousStyle != style
+                && GetWindowState(windowHandle) != WindowState.Maximized;
+            RectInt contentRect = default;
+            if (preserveGeometry)
+            {
+                contentRect = InsetByExtents(GetWindowRect(windowHandle), GetFrameExtents(windowHandle));
+                if (contentRect.width < 1 || contentRect.height < 1) preserveGeometry = false;
+            }
+
             // Update cache first so GetWindowStyle returns the right value immediately
             windowStyles[windowHandle] = style;
 
@@ -420,7 +434,99 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
                 LibX11.XFlush(display);
             }
 
+            // Toggling decorations makes the WM re-place/re-size the window (Mutter
+            // reverts it to a default geometry). Re-assert the captured content rect so
+            // size stays put — and, where the client may position itself (native X11),
+            // position too. Under XWayland the compositor honors the resize and ignores
+            // the move, which is exactly the achievable split.
+            if (preserveGeometry)
+                RestoreContentRect(windowHandle, contentRect, style == WindowStyle.Native);
+
             return true;
+        }
+
+        // Shrinks an outer (frame) rect by the window manager's decoration extents to
+        // get the content/client rect.
+        RectInt InsetByExtents(RectInt outer, (int left, int right, int top, int bottom) e)
+        {
+            return new RectInt(
+                outer.x + e.left,
+                outer.y + e.top,
+                System.Math.Max(outer.width - e.left - e.right, 1),
+                System.Math.Max(outer.height - e.top - e.bottom, 1));
+        }
+
+        // Re-applies a target content rect after a decoration change, expanding it to the
+        // outer frame via the new decoration extents. If keeping the content fixed would
+        // push the decorated frame outside the work area (title bar above the top panel
+        // being the common case), falls back to keeping the frame inside the old content
+        // box and letting the content shrink instead.
+        void RestoreContentRect(nint windowHandle, RectInt content, bool expectDecorations)
+        {
+            var e = WaitForFrameExtents(windowHandle, expectDecorations);
+
+            RectInt outer = new RectInt(
+                content.x - e.left,
+                content.y - e.top,
+                content.width + e.left + e.right,
+                content.height + e.top + e.bottom);
+
+            RectInt wa = GetWorkareaFor(windowHandle);
+            bool outOfBounds =
+                outer.x < wa.x ||
+                outer.y < wa.y ||
+                outer.x + outer.width > wa.x + wa.width ||
+                outer.y + outer.height > wa.y + wa.height;
+            if (outOfBounds)
+                outer = content; // outer-window preservation
+
+            // SetWindowRect configures the toplevel frame; under XWayland the compositor
+            // honors the size and ignores the position (the desired split).
+            SetWindowRect(windowHandle, outer);
+        }
+
+        // Reads _NET_FRAME_EXTENTS (left, right, top, bottom). Returns zeros when the WM
+        // publishes no extents (undecorated window, or compositors like wlroots that
+        // don't draw server-side decorations for X11 windows).
+        (int left, int right, int top, int bottom) GetFrameExtents(nint windowHandle)
+        {
+            nint atom = Atom("_NET_FRAME_EXTENTS", true);
+            if (atom == 0) return (0, 0, 0, 0);
+
+            int result = LibX11.XGetWindowProperty(display, windowHandle, atom, 0, 4, false,
+                (nint)6 /* XA_CARDINAL */, out _, out int format, out nint itemCount, out _, out nint prop);
+            if (result != 0 || prop == 0 || format != 32 || (int)itemCount < 4)
+            {
+                if (prop != 0) LibX11.XFree(prop);
+                return (0, 0, 0, 0);
+            }
+            try
+            {
+                return (
+                    ReadXPropertyInt32(prop, 0),
+                    ReadXPropertyInt32(prop, 1),
+                    ReadXPropertyInt32(prop, 2),
+                    ReadXPropertyInt32(prop, 3));
+            }
+            finally
+            {
+                LibX11.XFree(prop);
+            }
+        }
+
+        // Polls until the frame extents match the expected decoration state (or a
+        // timeout), since the WM applies decorations asynchronously after the hint write.
+        (int left, int right, int top, int bottom) WaitForFrameExtents(nint windowHandle, bool expectDecorations)
+        {
+            var e = GetFrameExtents(windowHandle);
+            for (int i = 0; i < 20; i++) // up to ~400ms
+            {
+                bool hasDecorations = e.left != 0 || e.right != 0 || e.top != 0 || e.bottom != 0;
+                if (hasDecorations == expectDecorations) break;
+                System.Threading.Thread.Sleep(20);
+                e = GetFrameExtents(windowHandle);
+            }
+            return e;
         }
 
         private nint GetToplevelParent(nint window)

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/LinuxX11/LinuxX11NativeWindowProvider.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/LinuxX11/LinuxX11NativeWindowProvider.cs
@@ -16,6 +16,26 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
         private Dictionary<nint, XSizeHints> savedSizeHints = new();
         private bool eventMaskSubscribed;
 
+        private bool? isXWayland;
+
+        /// <summary>
+        /// True when running under XWayland (a Wayland compositor), where the
+        /// compositor owns window placement and client positioning is ignored.
+        /// </summary>
+        private bool IsXWayland
+        {
+            get
+            {
+                isXWayland ??=
+                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"))
+                    || string.Equals(Environment.GetEnvironmentVariable("XDG_SESSION_TYPE"),
+                        "wayland", StringComparison.OrdinalIgnoreCase);
+                return isXWayland.Value;
+            }
+        }
+
+        public bool SupportsClientPositioning => !IsXWayland;
+
         public nint GetMainWindowHandle()
         {
             if (display == 0)
@@ -238,19 +258,24 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
                     SendNetWmState(windowHandle, 1, "_NET_WM_STATE_MAXIMIZED_VERT", "_NET_WM_STATE_MAXIMIZED_HORZ");
 
                     // Manual resize as a belt-and-braces fallback in case Mutter
-                    // doesn't do it on its own before our poll expires.
-                    if (waForHints.width > 0 && waForHints.height > 0)
-                        SetWindowRect(windowHandle, waForHints);
-
-                    var preSize = new Vector2Int(
-                        preMaximizeRects[windowHandle].width,
-                        preMaximizeRects[windowHandle].height);
-                    for (int i = 0; i < 25; i++) // up to ~500ms
+                    // doesn't do it on its own before our poll expires. Skipped under
+                    // XWayland, where client positioning/sizing is ignored and would
+                    // only fight the compositor.
+                    if (SupportsClientPositioning)
                     {
-                        var r = GetWindowRect(windowHandle);
-                        if (r.width != preSize.x || r.height != preSize.y)
-                            break;
-                        System.Threading.Thread.Sleep(20);
+                        if (waForHints.width > 0 && waForHints.height > 0)
+                            SetWindowRect(windowHandle, waForHints);
+
+                        var preSize = new Vector2Int(
+                            preMaximizeRects[windowHandle].width,
+                            preMaximizeRects[windowHandle].height);
+                        for (int i = 0; i < 25; i++) // up to ~500ms
+                        {
+                            var r = GetWindowRect(windowHandle);
+                            if (r.width != preSize.x || r.height != preSize.y)
+                                break;
+                            System.Threading.Thread.Sleep(20);
+                        }
                     }
 
                     maximizedFlags[windowHandle] = true;
@@ -260,7 +285,11 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
 
                     if (preMaximizeRects.TryGetValue(windowHandle, out var prev))
                     {
-                        SetWindowRect(windowHandle, prev);
+                        // Restoring an explicit rect only works where the client may
+                        // position itself; under XWayland the compositor restores the
+                        // pre-maximize geometry on its own.
+                        if (SupportsClientPositioning)
+                            SetWindowRect(windowHandle, prev);
                         preMaximizeRects.Remove(windowHandle);
                     }
 
@@ -378,12 +407,18 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
             LibX11.XChangeProperty(display, windowHandle, motifHints, motifHints, 32, 0, ref hints, 5);
             LibX11.XFlush(display);
 
-            // Unmap/remap to force WM to re-read the Motif hints.
-            // XSync between unmap and remap is required so the WM processes the unmap first.
-            LibX11.XUnmapWindow(display, windowHandle);
-            LibX11.XSync(display, false);
-            LibX11.XMapWindow(display, windowHandle);
-            LibX11.XFlush(display);
+            // Unmap/remap to force the WM to re-read the Motif hints. Done only on
+            // native X11: under XWayland (notably wlroots: Sway/Hyprland) a remap can
+            // cause focus loss, flashes, or be treated as a brand-new window (re-tiling).
+            // Mutter/KWin pick up the change from the property write above instead.
+            if (SupportsClientPositioning)
+            {
+                // XSync between unmap and remap is required so the WM processes the unmap first.
+                LibX11.XUnmapWindow(display, windowHandle);
+                LibX11.XSync(display, false);
+                LibX11.XMapWindow(display, windowHandle);
+                LibX11.XFlush(display);
+            }
 
             return true;
         }
@@ -581,7 +616,22 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.LinuxX11
 
         public bool StartWindowResize(nint windowHandle, Vector2Int pointerPosition, WindowResizeEdge edge)
         {
-            return false;
+            // EWMH _NET_WM_MOVERESIZE direction constants. Delegates the resize to the
+            // window manager / compositor, which works on native X11 and XWayland alike.
+            int direction = edge switch
+            {
+                WindowResizeEdge.TopLeft => 0,
+                WindowResizeEdge.Top => 1,
+                WindowResizeEdge.TopRight => 2,
+                WindowResizeEdge.Right => 3,
+                WindowResizeEdge.BottomRight => 4,
+                WindowResizeEdge.Bottom => 5,
+                WindowResizeEdge.BottomLeft => 6,
+                WindowResizeEdge.Left => 7,
+                _ => -1,
+            };
+            if (direction < 0) return false;
+            return SendMoveResize(windowHandle, pointerPosition, direction);
         }
 
         bool SendMoveResize(nint windowHandle, Vector2Int pointerPosition, int direction)

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/NativeWindowController.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/NativeWindowController.cs
@@ -28,6 +28,15 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow
             return Provider != null;
         }
 
+        public bool SupportsClientPositioning
+        {
+            get
+            {
+                EnsureInitialized();
+                return Provider?.SupportsClientPositioning ?? true;
+            }
+        }
+
         public nint GetMainWindowHandle()
         {
             if (IsAvailable) return Provider.GetMainWindowHandle();

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/Windows/WindowsNativeWindowProvider.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/Internal/NativeWindow/Windows/WindowsNativeWindowProvider.cs
@@ -11,6 +11,8 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI.Internal.NativeWindow.Windows
     {
         readonly WindowsNativeWindowHookManager hookManager = new();
 
+        public bool SupportsClientPositioning => true;
+
         public nint GetMainWindowHandle()
         {
             var h = Process.GetCurrentProcess().MainWindowHandle;

--- a/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/NativeWindow.cs
+++ b/Assets/JANOARG.Chartmaker/Scripts/Utils/NativeAPI/NativeWindow.cs
@@ -23,13 +23,21 @@ namespace JANOARG.Chartmaker.Utils.NativeAPI
             }
         }
 
-        public static bool IsApiAvailable 
+        public static bool IsApiAvailable
         {
-            get 
+            get
             {
                 return Controller.IsAvailable;
             }
         }
+
+        /// <summary>
+        /// Whether the app can position/size its own top-level window directly.
+        /// True on native X11 (and Windows); false under XWayland, where the
+        /// compositor owns window placement. Used to gate client-positioning
+        /// fallbacks that are no-ops under XWayland.
+        /// </summary>
+        public bool SupportsClientPositioning => Controller.SupportsClientPositioning;
 
         private NativeWindow(nint handle)
         {


### PR DESCRIPTION
## Context

On Linux the borderless custom window (custom title bar, drag, resize, maximize/restore) is driven by an X11/Xlib P/Invoke provider that targeted **native X11 only**. Under **XWayland** (X11 apps on a Wayland compositor — Mutter, KWin, wlroots/Sway/Hyprland) two restrictions broke it:

- Client-initiated absolute positioning (`XMoveWindow` / `XConfigureWindow` x,y) is ignored — the compositor owns placement.
- `XQueryPointer` global coordinates are unreliable once the pointer leaves the app surface.

These broke the manual pointer-delta **drag** loop and the manual **resize** loop (resize was doubly broken since `StartWindowResize` was unimplemented).

## Approach

Delegate interactive move/resize to the WM/compositor via EWMH `_NET_WM_MOVERESIZE` — standard, honored by all EWMH WMs and by XWayland on every compositor — and gate the remaining client-positioning fallbacks to native X11 only.

- **`SupportsClientPositioning` capability** threaded provider → controller → facade. `false` under XWayland (detected via `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE`), `true` on native X11 and Windows.
- **Implemented `StartWindowResize`** via `_NET_WM_MOVERESIZE` direction constants (reuses the existing `SendMoveResize` helper that already backed drag).
- **Robust start coords**: `WindowHandler` computes root-relative pointer coords from `Rect` + `Input.mousePosition` instead of `XQueryPointer`.
- **Removed the manual pointer-delta drag/resize loops**; gated the maximize/restore rect fallback, post-action position nudges, and the Motif `unmap`/`remap` trick to native X11 only.

## Files

- `NativeAPI/Internal/NativeWindow/LinuxX11/LinuxX11NativeWindowProvider.cs` — detection, `StartWindowResize`, gating in `SetWindowState`/`SetWindowStyle`
- `NativeAPI/Internal/NativeWindow/INativeWindowProvider.cs`, `Windows/WindowsNativeWindowProvider.cs`, `NativeWindowController.cs`, `NativeAPI/NativeWindow.cs` — capability flag
- `Behaviors/Chartmaker/WindowHandler.cs` — route to compositor move/resize, root-coord helper, remove manual loops, gate nudges

## Verification

Unity project — needs an Editor build. Test the Linux player: drag, 8-edge resize, maximize/restore, minimize, min-size clamp, and Native/Custom frame-mode toggle on **native X11** and **XWayland (Mutter, KWin, wlroots)**. `SupportsClientPositioning` should report `false` under XWayland / `true` on native X11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)